### PR TITLE
util/makeImage.sh: Minor bug fix

### DIFF
--- a/util/makeImage.sh
+++ b/util/makeImage.sh
@@ -36,7 +36,7 @@ sync
 
 echo "~~~ Create Image Mounting Directory ~~~"
 if [ ! -e "${IMAGE_DIR}" ]; then
-    mkdir "${IMAGE_DIR}"
+    mkdir -p "${IMAGE_DIR}"
     chown "${USER}" "${IMAGE_DIR}"
 fi
 


### PR DESCRIPTION
Added the -p argument to mkdir -p "${IMAGE_DIR}". This allows the creation of the directory in a fresh install of IFFSET where the mounters directory does not yet exist.